### PR TITLE
Add MiniMax-M3 image input support

### DIFF
--- a/src/llama_cookbook/inference/llm.py
+++ b/src/llama_cookbook/inference/llm.py
@@ -11,7 +11,7 @@ import logging
 
 import time
 from abc import ABC, abstractmethod
-from typing import Callable
+from typing import Callable, Literal
 
 import openai
 from typing_extensions import override
@@ -22,6 +22,11 @@ TEMPERATURE = 0.1
 TOP_P = 0.9
 
 LOG: logging.Logger = logging.getLogger(__name__)
+
+MINIMAX_BASE_URLS = {
+    "global": "https://api.minimax.io/v1",
+    "china": "https://api.minimaxi.com/v1",
+}
 
 
 class LLM(ABC):
@@ -157,3 +162,44 @@ class ANYSCALE(LLM):
             "mistralai/Mistral-7B-Instruct-v0.1",
             "HuggingFaceH4/zephyr-7b-beta",
         ]
+
+
+class MINIMAX(LLM):
+    """Access MiniMax-M3 through its hosted OpenAI-compatible API."""
+
+    def __init__(
+        self,
+        model: str,
+        api_key: str,
+        region: Literal["global", "china"] = "global",
+    ) -> None:
+        super().__init__(model, api_key)
+        self.client = openai.OpenAI(base_url=MINIMAX_BASE_URLS[region], api_key=api_key)
+
+    @override
+    def query(self, prompt: str, image_url: str | None = None) -> str:
+        content: str | list[dict[str, object]] = prompt
+        if image_url is not None:
+            content = [
+                {"type": "text", "text": prompt},
+                {
+                    "type": "image_url",
+                    "image_url": {"url": image_url, "detail": "default"},
+                },
+            ]
+
+        level = logging.getLogger().level
+        logging.getLogger().setLevel(logging.WARNING)
+        try:
+            response = self.client.chat.completions.create(
+                model=self.model,
+                messages=[{"role": "user", "content": content}],
+                max_tokens=MAX_TOKENS,
+            )
+            return response.choices[0].message.content or ""
+        finally:
+            logging.getLogger().setLevel(level)
+
+    @override
+    def valid_models(self) -> list[str]:
+        return ["MiniMax-M3"]

--- a/src/tests/test_llm.py
+++ b/src/tests/test_llm.py
@@ -1,0 +1,56 @@
+# Copyright (c) Meta Platforms, Inc. and affiliates.
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from llama_cookbook.inference.llm import MAX_TOKENS, MINIMAX
+
+
+def test_minimax_image_input() -> None:
+    response = SimpleNamespace(
+        choices=[SimpleNamespace(message=SimpleNamespace(content="A test image."))]
+    )
+
+    with patch("llama_cookbook.inference.llm.openai.OpenAI") as openai_client:
+        openai_client.return_value.chat.completions.create.return_value = response
+
+        provider = MINIMAX("MiniMax-M3", "test-key")
+
+        assert (
+            provider.query("Describe this image.", "https://example.com/image.png")
+            == "A test image."
+        )
+        openai_client.assert_called_once_with(
+            base_url="https://api.minimax.io/v1", api_key="test-key"
+        )
+        openai_client.return_value.chat.completions.create.assert_called_once_with(
+            model="MiniMax-M3",
+            messages=[
+                {
+                    "role": "user",
+                    "content": [
+                        {"type": "text", "text": "Describe this image."},
+                        {
+                            "type": "image_url",
+                            "image_url": {
+                                "url": "https://example.com/image.png",
+                                "detail": "default",
+                            },
+                        },
+                    ],
+                }
+            ],
+            max_tokens=MAX_TOKENS,
+        )
+
+
+def test_minimax_china_endpoint() -> None:
+    with patch("llama_cookbook.inference.llm.openai.OpenAI") as openai_client:
+        MINIMAX("MiniMax-M3", "test-key", region="china")
+
+        openai_client.assert_called_once_with(
+            base_url="https://api.minimaxi.com/v1", api_key="test-key"
+        )


### PR DESCRIPTION
Reason: Add MiniMax-M3 image input support to the hosted adapter.

This change:

- sends image URLs as compatible multimodal message content;
- supports both global and China hosted endpoints; and
- adds mocked unit coverage for the image payload and endpoint selection.

Checks:

- `PYTHONPATH=src python -m pytest --noconftest -q src/tests/test_llm.py`
- `black --target-version py38 --check src/tests/test_llm.py`
- `python -m py_compile src/llama_cookbook/inference/llm.py src/tests/test_llm.py`
- `git diff --check`
